### PR TITLE
Update muelu-cheby2er12-drop0.02-smoo-rebaltarg10k-explR-rebalPR-aggs…

### DIFF
--- a/nrel_5mw/g1/muelu-cheby2er12-drop0.02-smoo-rebaltarg10k-explR-rebalPR-aggsize.xml
+++ b/nrel_5mw/g1/muelu-cheby2er12-drop0.02-smoo-rebaltarg10k-explR-rebalPR-aggsize.xml
@@ -5,8 +5,19 @@
   <Parameter name="transpose: use implicit"                 type="bool"     value="false"/>
   <Parameter name="repartition: rebalance P and R"          type="bool"     value="true"/>
 
-  <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
-  <ParameterList    name="smoother: params">
+  <Parameter        name="smoother: pre or post"            type="string"   value="both"/>
+
+  <Parameter        name="smoother: pre type"              type="string"   value="CHEBYSHEV"/>
+  <ParameterList    name="smoother: pre params">
+    <Parameter      name="chebyshev: degree"                    type="int"      value="1"/>>
+    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="12"/>
+    <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+    <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+    <Parameter      name="chebyshev: eigenvalue max iterations" type="int"      value="10"/>
+  </ParameterList>
+
+  <Parameter        name="smoother: post type"              type="string"   value="CHEBYSHEV"/>
+  <ParameterList    name="smoother: post params">
     <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>>
     <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="12"/>
     <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>


### PR DESCRIPTION
reducing the number of V-cycle pre-sweeps to 1 from 2 maintains the same GMRES iteration 
counts for the continuity solver. The solver time drops by 1/2 and the overall Nalu-Wind run time
is reduced 10-20%. Tested with Chebyshev smoother on G1 mesh (Cori)

sthomas1@cori07:/global/cscratch1/sd/sthomas1/g1> fgrep "solve --" nrel_5mw_g1-muelu-128-gmres-cheb-1.log
            solve --       avg: 0     min: 0     max: 0
            solve --       avg: 488.069     min: 486.7     max: 489.225
            solve --       avg: 352.963     min: 352.942     max: 352.972
sthomas1@cori07:/global/cscratch1/sd/sthomas1/g1> fgrep "solve --" nrel_5mw_g1-muelu-128-gmres-cheby-post-1.log
            solve --       avg: 0     min: 0     max: 0
            solve --       avg: 488.481     min: 487.096     max: 489.641
            solve --       avg: 160.619     min: 160.603     max: 160.627